### PR TITLE
CI: use PyPI API token when available

### DIFF
--- a/.github/workflows/python-package-test.yml
+++ b/.github/workflows/python-package-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python-version: ["3.6","3.7","3.8", "3.9", "3.10"]
+        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12","3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package-test.yml
+++ b/.github/workflows/python-package-test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       max-parallel: 2

--- a/.github/workflows/python-package-test.yml
+++ b/.github/workflows/python-package-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12","3.13"]
+        python-version: ["3.10","3.11","3.12","3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,8 +24,14 @@ jobs:
         pip install setuptools wheel twine
     - name: Build and publish
       env:
+        PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        python -m pip install --quiet --upgrade twine
+        if [ -n "${PYPI_API_TOKEN}" ]; then
+          twine upload --username "__token__" --password "${PYPI_API_TOKEN}" dist/*
+        else
+          twine upload --username "${TWINE_USERNAME}" --password "${TWINE_PASSWORD}" dist/*
+        fi

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="hishiryo", 
-    version="0.0.3",
+    version="0.0.4",
     author="Nicolas Boisseau",
     author_email="spriggancg@gmail.com",
     description="Render a dataset into a picture",
@@ -16,7 +16,7 @@ setuptools.setup(
     packages=setuptools.find_packages('src'),
     package_dir={'': 'src'},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
-    install_requires=['pandas<=1.3.5', 'opencv-python'],
+    install_requires=['pandas>=1.3.5', 'opencv-python'],
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/src/hishiryo/_toolbox.py
+++ b/src/hishiryo/_toolbox.py
@@ -269,9 +269,9 @@ class Mixin:
                 column_max = dataset_df[current_column].max()
 
                 if dataset_df[current_column].dtypes == "float64":
-                    dataset_df[current_column].fillna(0.0, inplace=True)
+                    dataset_df[current_column] = dataset_df[current_column].fillna(0.0)
                 if dataset_df[current_column].dtypes == "int64":
-                    dataset_df[current_column].fillna(0, inplace=True)
+                    dataset_df[current_column] = dataset_df[current_column].fillna(0)
 
                 #  get the dataseries
 
@@ -295,7 +295,7 @@ class Mixin:
 
                 except ValueError:
                     column_data = pd.to_numeric(column_data, errors="coerce")
-                    column_data.fillna(value=0, inplace=True)
+                    column_data = column_data.fillna(0)
 
                     column_data_rgb = [
                         (
@@ -308,18 +308,19 @@ class Mixin:
 
                 # write the pixels
                 for current_pixel in range(0, bitmap_height):
-                    current_bitmap_opencv[current_pixel, id] = [
+                    vals = [
                         column_data_rgb[current_pixel][2],
                         column_data_rgb[current_pixel][1],
                         column_data_rgb[current_pixel][0],
                     ]
+                    current_bitmap_opencv[current_pixel, id] = np.clip(vals, 0, 255).astype(np.uint8)
 
             elif dataset_df[current_column].dtypes == "object":
 
                 colorTint = (0.5, 1.0, 0.5)
 
                 #  remove the nan and replace it with zero. (it's not an object for sure..)
-                dataset_df[current_column].fillna(0, inplace=True)
+                dataset_df[current_column] = dataset_df[current_column].fillna(0)
                 #  get the modalities.
                 column_labels = set(dataset_df[current_column].values.tolist())
 
@@ -333,7 +334,7 @@ class Mixin:
                     )
 
                 #  get the dataseries
-                dataset_df[current_column].fillna(0, inplace=True)
+                dataset_df[current_column] = dataset_df[current_column].fillna(0)
                 column_data = dataset_df[current_column].values.tolist()
                 column_data_rgb = [
                     (
@@ -346,11 +347,12 @@ class Mixin:
 
                 # write the pixels
                 for current_pixel in range(0, bitmap_height):
-                    current_bitmap_opencv[current_pixel, id] = [
+                    vals = [
                         column_data_rgb[current_pixel][2],
                         column_data_rgb[current_pixel][1],
                         column_data_rgb[current_pixel][0],
                     ]
+                    current_bitmap_opencv[current_pixel, id] = np.clip(vals, 0, 255).astype(np.uint8)
             else:
                 print("Column type unknown")
 


### PR DESCRIPTION
Prefer PYPI_API_TOKEN (username __token__) for twine uploads; fallback to PYPI_USERNAME/PYPI_PASSWORD. This prevents 403 when using API tokens.